### PR TITLE
Disjoint intervals bug fix

### DIFF
--- a/src/libra/abstract_domains/interval2_domain.py
+++ b/src/libra/abstract_domains/interval2_domain.py
@@ -178,7 +178,6 @@ class Box2State(State, BoundsDomain):
         elif 0 <= lower or active:
             if active and lower < 0:
                 self.bounds[name] = IntervalLattice(0, upper)
-                del self.symbols[name]
             self.flag = 1
         else:   # case (c) in Fig. 4, equation (4)
             _active, _inactive = deepcopy(self.bounds), deepcopy(self.bounds)

--- a/src/libra/abstract_domains/interval2_domain.py
+++ b/src/libra/abstract_domains/interval2_domain.py
@@ -178,6 +178,7 @@ class Box2State(State, BoundsDomain):
         elif 0 <= lower or active:
             if active and lower < 0:
                 self.bounds[name] = IntervalLattice(0, upper)
+                del self.symbols[name]
             self.flag = 1
         else:   # case (c) in Fig. 4, equation (4)
             _active, _inactive = deepcopy(self.bounds), deepcopy(self.bounds)

--- a/src/libra/abstract_domains/neurify_domain.py
+++ b/src/libra/abstract_domains/neurify_domain.py
@@ -80,8 +80,13 @@ class NeurifyState(State, BoundsDomain):
     @copy_docstring(State._join)
     def _join(self, other: 'NeurifyState') -> 'NeurifyState':
         for var in self.bounds:
-            self.bounds[var][LOW].join(other.bounds[var][LOW])
-            self.bounds[var][UP].join(other.bounds[var][UP])
+            other_bound = IntervalLattice(other.bounds[var][LOW].lower, other.bounds[var][UP].upper)
+            self_bound = IntervalLattice(self.bounds[var][LOW].lower, self.bounds[var][UP].upper)
+            self_bound.join(other_bound)
+            self.bounds[var] = (
+                IntervalLattice(self_bound.lower, self_bound.lower),
+                IntervalLattice(self_bound.upper, self_bound.upper))
+
             self.poly[var] = (
                 {'_': self.bounds[var][LOW].lower},
                 {'_': self.bounds[var][UP].upper})
@@ -90,8 +95,13 @@ class NeurifyState(State, BoundsDomain):
     @copy_docstring(State._meet)
     def _meet(self, other: 'NeurifyState') -> 'NeurifyState':
         for var in self.bounds:
-            self.bounds[var][LOW].meet(other.bounds[var][LOW])
-            self.bounds[var][UP].meet(other.bounds[var][UP])
+            other_bound = IntervalLattice(other.bounds[var][LOW].lower, other.bounds[var][UP].upper)
+            self_bound = IntervalLattice(self.bounds[var][LOW].lower, self.bounds[var][UP].upper)
+            self_bound.meet(other_bound)
+            self.bounds[var] = (
+                IntervalLattice(self_bound.lower, self_bound.lower),
+                IntervalLattice(self_bound.upper, self_bound.upper))
+
             self.poly[var] = (
                 {'_': self.bounds[var][LOW].lower},
                 {'_': self.bounds[var][UP].upper})

--- a/src/libra/abstract_domains/neurify_domain.py
+++ b/src/libra/abstract_domains/neurify_domain.py
@@ -269,7 +269,6 @@ class NeurifyState(State, BoundsDomain):
         elif 0 <= up_lower or active:
             if active and up_lower < 0:
                 self.bounds[name] = (self.bounds[name][LOW], IntervalLattice(0, up_upper))
-                self.poly[name] = (self.poly[name][LOW], {'_': 0.0})
         else:
             m = up_upper / (up_upper - up_lower)
             q = up_upper * (-up_lower) / (up_upper - up_lower)

--- a/src/libra/abstract_domains/product_domain.py
+++ b/src/libra/abstract_domains/product_domain.py
@@ -5,6 +5,7 @@ Bias Abstract Domain: Product between DeepPoly and Neurify
 Disjunctive relation abstract domain to be used for **algorithmic bias analysis**.
 
 """
+from copy import deepcopy
 from typing import Set, List, Dict
 
 from apronpy.texpr1 import PyTexpr1
@@ -97,7 +98,9 @@ class ProductState(State):
 
     def assume(self, condition, manager: PyManager = None, bwd: bool = False) -> 'ProductState':
         for domain in self._domains:
-            domain.assume(condition, manager, bwd)
+            domain.assume(deepcopy(condition), manager, bwd)
+        for input in self.inputs:
+            self._share_bounds(str(input))
         return self
 
     @copy_docstring(State._substitute)

--- a/src/libra/abstract_domains/product_domain.py
+++ b/src/libra/abstract_domains/product_domain.py
@@ -118,19 +118,6 @@ class ProductState(State):
             upper, lower = lower, upper
         self.bounds[var_name] = IntervalLattice(lower, upper)
 
-        if self.bounds[var_name].is_bottom():
-            self.bounds[var_name] = IntervalLattice(
-                min([domain.get_bounds(var_name).lower for domain in self._domains]),
-                max([domain.get_bounds(var_name).upper for domain in self._domains])
-            )
-            # print(f"> Exception status fo var {var_name}:")
-            # for domain in self._domains:
-            #     print(f"> [{var_name}] Domain {type(domain)}: ({domain.get_bounds(var_name)})")
-            # print(f"> Input partition: ")
-            # for input in self.inputs:
-            #     b = self._domains[0].get_bounds(str(input))
-            #     print(f"> assume({b.lower} <= {input} <= {b.upper})")
-            # raise Exception(f"self.bounds[{var_name}] = {self.bounds[var_name]} (lower={max([domain.get_bounds(var_name).lower for domain in self._domains])}, upper={min([domain.get_bounds(var_name).upper for domain in self._domains])})")
         for domain in self._domains:
             domain.resize_bounds(var_name, self.bounds[var_name])
 

--- a/src/libra/abstract_domains/product_domain.py
+++ b/src/libra/abstract_domains/product_domain.py
@@ -111,8 +111,6 @@ class ProductState(State):
         raise NotImplementedError(f"Call to _forget is unexpected!")
 
     def _share_bounds(self, var_name):
-        max([domain.get_bounds(var_name).lower for domain in self._domains])
-        min([domain.get_bounds(var_name).upper for domain in self._domains])
         self.bounds[var_name] = IntervalLattice(
             max([domain.get_bounds(var_name).lower for domain in self._domains]),
             min([domain.get_bounds(var_name).upper for domain in self._domains])
@@ -122,6 +120,14 @@ class ProductState(State):
                 min([domain.get_bounds(var_name).lower for domain in self._domains]),
                 max([domain.get_bounds(var_name).upper for domain in self._domains])
             )
+            # print(f"> Exception status fo var {var_name}:")
+            # for domain in self._domains:
+            #     print(f"> [{var_name}] Domain {type(domain)}: ({domain.get_bounds(var_name)})")
+            # print(f"> Input partition: ")
+            # for input in self.inputs:
+            #     b = self._domains[0].get_bounds(str(input))
+            #     print(f"> assume({b.lower} <= {input} <= {b.upper})")
+            # raise Exception(f"self.bounds[{var_name}] = {self.bounds[var_name]} (lower={max([domain.get_bounds(var_name).lower for domain in self._domains])}, upper={min([domain.get_bounds(var_name).upper for domain in self._domains])})")
         for domain in self._domains:
             domain.resize_bounds(var_name, self.bounds[var_name])
 

--- a/src/libra/abstract_domains/product_domain.py
+++ b/src/libra/abstract_domains/product_domain.py
@@ -117,6 +117,11 @@ class ProductState(State):
             max([domain.get_bounds(var_name).lower for domain in self._domains]),
             min([domain.get_bounds(var_name).upper for domain in self._domains])
         )
+        if self.bounds[var_name].is_bottom():
+            self.bounds[var_name] = IntervalLattice(
+                min([domain.get_bounds(var_name).lower for domain in self._domains]),
+                max([domain.get_bounds(var_name).upper for domain in self._domains])
+            )
         for domain in self._domains:
             domain.resize_bounds(var_name, self.bounds[var_name])
 

--- a/src/libra/abstract_domains/product_domain.py
+++ b/src/libra/abstract_domains/product_domain.py
@@ -7,6 +7,7 @@ Disjunctive relation abstract domain to be used for **algorithmic bias analysis*
 """
 from copy import deepcopy
 from typing import Set, List, Dict
+from math import isclose
 
 from apronpy.texpr1 import PyTexpr1
 from apronpy.var import PyVar
@@ -111,10 +112,12 @@ class ProductState(State):
         raise NotImplementedError(f"Call to _forget is unexpected!")
 
     def _share_bounds(self, var_name):
-        self.bounds[var_name] = IntervalLattice(
-            max([domain.get_bounds(var_name).lower for domain in self._domains]),
-            min([domain.get_bounds(var_name).upper for domain in self._domains])
-        )
+        lower = max([domain.get_bounds(var_name).lower for domain in self._domains])
+        upper = min([domain.get_bounds(var_name).upper for domain in self._domains])
+        if upper < lower and isclose(lower, upper):
+            upper, lower = lower, upper
+        self.bounds[var_name] = IntervalLattice(lower, upper)
+
         if self.bounds[var_name].is_bottom():
             self.bounds[var_name] = IntervalLattice(
                 min([domain.get_bounds(var_name).lower for domain in self._domains]),

--- a/src/libra/abstract_domains/symbolic3_domain.py
+++ b/src/libra/abstract_domains/symbolic3_domain.py
@@ -281,6 +281,7 @@ class Symbolic3State(State, BoundsDomain):
             if active and lower < 0:
                 bounds = self.bounds[name]
                 self.bounds[name] = bounds.meet(IntervalLattice(0, upper))
+                del self.symbols[name]
             self.flag = 1
         else:
             _active, _inactive = deepcopy(self.bounds), deepcopy(self.bounds)

--- a/src/libra/engine/forward_runner.py
+++ b/src/libra/engine/forward_runner.py
@@ -125,7 +125,8 @@ class ForwardAnalysis(Runner):
             for node in self.cfg.successors(current):
                 worklist.put(node)
 
-    def main(self, path):
+
+    def main(self, path, forced_active=None, forced_inactive=None):
         self.path = path
         with open(self.path, 'r') as source:
             self.source = source.read()
@@ -138,7 +139,7 @@ class ForwardAnalysis(Runner):
                 r_vars.append(PyVar(variable.name))
             environment = PyEnvironment([], r_vars)
             self.lyra2apron(environment)
-        self.run()
+        self.run(forced_active=forced_active, forced_inactive=forced_inactive)
 
-    def run(self):
-        self.interpreter().analyze(self.state(), outputs=self.outputs)
+    def run(self, forced_active=None, forced_inactive=None):
+        self.interpreter().analyze(self.state(), outputs=self.outputs, forced_active=forced_active, forced_inactive=forced_inactive)

--- a/src/libra/forward_tester.py
+++ b/src/libra/forward_tester.py
@@ -3,22 +3,35 @@ forward runner to toy example
 """
 import sys
 
+from apronpy.var import PyVar
+from libra.core.cfg import Activation
+
 from libra.engine.forward_runner import ForwardAnalysis
 from libra.engine.bias_analysis import AbstractDomain
 from libra.main import checker
 
 spec = 'tests/census/census.txt'
-nn = 'tests/census/12.py'
+nn = 'tests/census/20.py'
 if len(sys.argv) > 1:
     domain = checker(sys.argv[1])
 else:
-    domain = AbstractDomain.NEURIFY # default
+    domain = AbstractDomain.NEURIFY_SYMBOLIC3 # default
 print(f"> Domain chosen: '{domain}'")
 b = ForwardAnalysis(spec, domain=domain, log=True)
-try:
-    b.main(nn)
-except NotImplementedError as e:
-    print(f"> NotImplementedError: '{e}'")
+# forced_active = {
+#     Activation(23+3, PyVar("x10")), 
+#     Activation(23+5, PyVar("x12")), 
+#     Activation(23+6, PyVar("x13")), 
+#     Activation(23+9, PyVar("x20")), 
+#     Activation(23+12, PyVar("x23"))
+# }
+# forced_inactive = {
+#     Activation(23+17, PyVar("x32")), 
+#     Activation(23+15, PyVar("x30")), 
+#     Activation(23+13, PyVar("x24")), 
+#     Activation(23+7, PyVar("x14"))
+# }
+b.main(nn) # , forced_active_names=forced_active, forced_inactive_names=forced_inactive)
 
 """
 By-hand analysis (exact, using rational numbers) using Neurify in the 'tests/oy.py' neural network:


### PR DESCRIPTION
Additionally, we fix:
- rounding errors causing bottom bounds in the product domain, where `lower > upper` but `lower = upper + epsilon`,
- the product domain supports `assume` statements at the start of neural network models,
- the forward tester supports custom `forced_active` and `forced_inactive` sets.